### PR TITLE
Fix for footnote anchor

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -230,7 +230,7 @@ class ParsedownExtra extends Parsedown
                 'handler' => 'element',
                 'text' => array(
                     'name' => 'a',
-                    'attributes' => array('href' => '#fn:'.$name, 'class' => 'footnote-ref'),
+                    'attributes' => array('href' => '#fn:'.($name-1), 'class' => 'footnote-ref'),
                     'text' => $this->Definitions['Footnote'][$name]['number'],
                 ),
             );
@@ -318,7 +318,7 @@ class ParsedownExtra extends Parsedown
 
             foreach (range(1, $Data['count']) as $number)
             {
-                $text .= '&#160;<a href="#fnref'.$number.':'.$name.'" rev="footnote" class="footnote-backref">&#8617;</a>';
+                $text .= '&#160;<a href="#fnref'.$number.':'.($name+1).'" rev="footnote" class="footnote-backref">&#8617;</a>';
             }
 
             $Element['text'][1]['text'] []= array(


### PR DESCRIPTION
I've seen another pull request regarding this issue but the fix seems to introduce a new bug. This should fix the footnote bug when clicking back and forth between footnote & footnote anchors (current version links to the wrong footnotes). 

This fix does not correct the numbering, which is wrong. `#fn-0` is the first footnote. This should not be zero-based, right?