### PR TITLE
removed inline function for older PHP versions (5.2+)

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -325,6 +325,16 @@ class ParsedownExtra extends Parsedown
         return $text;
     }
 
+
+    #
+    # ~
+    #
+
+    protected function footnoteSort($A, $B) {
+        return $A['number'] - $B['number'];
+    }
+
+
     #
     # ~
     #
@@ -347,9 +357,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        usort($this->Definitions['Footnote'], function($A, $B) {
-            return $A['number'] - $B['number'];
-        });
+        usort($this->Definitions['Footnote'], array('ParsedownExtra', 'footnoteSort'));
 
         foreach ($this->Definitions['Footnote'] as $name => $Data)
         {


### PR DESCRIPTION
The inline function syntax is only valid in PHP 5.3 and higher.  It is not available in PHP 5.2.  This change will  allow Parsedown Extra to work in PHP versions 5.2+.