### PR TITLE
Fixes fnrefs for named footnotes

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -352,21 +352,17 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
+        foreach ($this->Definitions['Footnote'] as $name => $Data) {
+            $this->Definitions['Footnote'][$name]["name"] = $name;
+        }
+
         usort($this->Definitions['Footnote'], function($A, $B) {
             return $A['number'] - $B['number'];
         });
 
         foreach ($this->Definitions['Footnote'] as $name => $Data)
         {
-            if ( ! isset($Data["name"]))
-            {
-                continue;
-            }
-            else 
-            {
-              $name = $Data["name"];
-            }
-
+            $name = $Data["name"];
             $text = $Data['text'];
             $text = $this->line($text);
 

--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -358,9 +358,13 @@ class ParsedownExtra extends Parsedown
 
         foreach ($this->Definitions['Footnote'] as $name => $Data)
         {
-            if ( ! isset($Data['number']))
+            if ( ! isset($Data["name"]))
             {
                 continue;
+            }
+            else 
+            {
+              $name = $Data["name"];
             }
 
             $text = $Data['text'];


### PR DESCRIPTION
[^my-footnote] now generates the correct footnote markers and return links in footnote elements - #fnref1:my-footnote