### PR TITLE
wrong index for $name in buildFootnoteElement()

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -368,12 +368,12 @@ class ParsedownExtra extends Parsedown
 
             foreach (range(1, $Data['count']) as $number)
             {
-                $text .= '&#160;<a href="#fnref'.$number.':'.$name.'" rev="footnote" class="footnote-backref">&#8617;</a>';
+                $text .= '&#160;<a href="#fnref'.$number.':'.($name + 1).'" rev="footnote" class="footnote-backref">&#8617;</a>';
             }
 
             $Element['text'][1]['text'] []= array(
                 'name' => 'li',
-                'attributes' => array('id' => 'fn:'.$name),
+                'attributes' => array('id' => 'fn:'.($name + 1)),
                 'handler' => 'elements',
                 'text' => array(
                     array(


### PR DESCRIPTION
numbering in identifyFootnoteMarker() starts with 1, while in buildFootnoteElement() it starts with 0
