### PR TITLE
Added missing overridden method for `inlineImage()`

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -281,6 +281,25 @@ class ParsedownExtra extends Parsedown
     }
 
     #
+    # image
+
+    protected function inlineImage($excerpt)
+    {
+        $Span = parent::inlineImage($excerpt);
+
+        $remainder = substr($excerpt, $Span['extent']);
+
+        if (preg_match('/^[ ]*'.$this->attributesPattern.'/', $remainder, $matches))
+        {
+            $Span['element']['attributes'] += $this->parseAttributes($matches[1]);
+
+            $Span['extent'] += strlen($matches[0]);
+        }
+
+        return $Span;
+    }
+
+    #
     # ~
 
     protected function unmarkedText($text)


### PR DESCRIPTION
Issue https://github.com/erusev/parsedown-extra/issues/32 contains the details for this.

PR https://github.com/erusev/parsedown/pull/260 contains the corollary part of the equation.  