### PR TITLE
Add option to add unique prefix to footnote references

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -62,6 +62,18 @@ class ParsedownExtra extends Parsedown
     }
 
     #
+    # Setters
+    #
+
+    function setFootnotePrefix( $footnotePrefix )
+    {
+        $this->footnotePrefix = $footnotePrefix;
+        return $this;
+    }
+
+    protected $footnotePrefix = '';
+
+    #
     # Blocks
     #
 
@@ -275,13 +287,15 @@ class ParsedownExtra extends Parsedown
                 $this->DefinitionData['Footnote'][$name]['number'] = ++ $this->footnoteCount; # » &
             }
 
+            $fnPrefix = !empty( $this->footnotePrefix ) ? $this->footnotePrefix . ':' : '';
+
             $Element = array(
                 'name' => 'sup',
-                'attributes' => array('id' => 'fnref'.$this->DefinitionData['Footnote'][$name]['count'].':'.$name),
+                'attributes' => array('id' => 'fnref'.$fnPrefix.$this->DefinitionData['Footnote'][$name]['count'].':'.$name),
                 'handler' => 'element',
                 'text' => array(
                     'name' => 'a',
-                    'attributes' => array('href' => '#fn:'.$name, 'class' => 'footnote-ref'),
+                    'attributes' => array('href' => '#fn:'.$fnPrefix.$name, 'class' => 'footnote-ref'),
                     'text' => $this->DefinitionData['Footnote'][$name]['number'],
                 ),
             );
@@ -399,9 +413,11 @@ class ParsedownExtra extends Parsedown
 
             $backLinksMarkup = '';
 
+            $fnPrefix = !empty( $this->footnotePrefix ) ? $this->footnotePrefix . ':' : '';
+
             foreach ($numbers as $number)
             {
-                $backLinksMarkup .= ' <a href="#fnref'.$number.':'.$definitionId.'" rev="footnote" class="footnote-backref">&#8617;</a>';
+                $backLinksMarkup .= ' <a href="#fnref'.$fnPrefix.$number.':'.$definitionId.'" rev="footnote" class="footnote-backref">&#8617;</a>';
             }
 
             $backLinksMarkup = substr($backLinksMarkup, 1);
@@ -419,7 +435,7 @@ class ParsedownExtra extends Parsedown
 
             $Element['text'][1]['text'] []= array(
                 'name' => 'li',
-                'attributes' => array('id' => 'fn:'.$definitionId),
+                'attributes' => array('id' => 'fn:'.$fnPrefix.$definitionId),
                 'text' => "\n".$text."\n",
             );
         }

--- a/test/ParsedownExtraTest.php
+++ b/test/ParsedownExtraTest.php
@@ -17,4 +17,39 @@ class ParsedownExtraTest extends ParsedownTest
 
         return $Parsedown;
     }
+
+    public function test_footnote_prefix()
+    {
+        $markdownInput = file_get_contents( dirname( __FILE__ ) . '/data/footnote.md' );
+        $markdownInput = str_replace( "\r\n", "\n", $markdownInput );
+        $markdownInput = str_replace( "\r", "\n", $markdownInput );
+
+        $parsedown = new ParsedownExtra();
+        $parsedown->setFootnotePrefix( '123' );
+
+        $expectedOutput = <<< EOF
+<p>first <sup id="fnref123:1:1"><a href="#fn:123:1" class="footnote-ref">1</a></sup> second <sup id="fnref123:1:2"><a href="#fn:123:2" class="footnote-ref">2</a></sup>.</p>
+<p>first <sup id="fnref123:1:a"><a href="#fn:123:a" class="footnote-ref">3</a></sup> second <sup id="fnref123:1:b"><a href="#fn:123:b" class="footnote-ref">4</a></sup>.</p>
+<p>second time <sup id="fnref123:2:1"><a href="#fn:123:1" class="footnote-ref">1</a></sup></p>
+<div class="footnotes">
+<hr />
+<ol>
+<li id="fn:123:1">
+<p>one&#160;<a href="#fnref123:1:1" rev="footnote" class="footnote-backref">&#8617;</a> <a href="#fnref123:2:1" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+<li id="fn:123:2">
+<p>two&#160;<a href="#fnref123:1:2" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+<li id="fn:123:a">
+<p>one&#160;<a href="#fnref123:1:a" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+<li id="fn:123:b">
+<p>two&#160;<a href="#fnref123:1:b" rev="footnote" class="footnote-backref">&#8617;</a></p>
+</li>
+</ol>
+</div>
+EOF;
+        
+        $this->assertEquals( $expectedOutput, $parsedown->text( $markdownInput ) );
+    }
 }


### PR DESCRIPTION
Setting footnote prefix: ParsedownExtra::setFootnotePrefix( string $footnotePrefix )
	This should be a string that is valid in an HTML attribute, i.e. escaped properly.
	Default value is blank, if this is kept blank behavior is as before.
	Use case in mind is for something like a blog, where you can set the prefix to something unique like a post ID.

Added test_footnote_prefix() to test cases.

fixes #50 