### PR TITLE
Updated the attribute parser to handle extra attributes aside from just a `class` and `id`.

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -314,6 +314,26 @@ class ParsedownExtra extends Parsedown
         return $Link;
     }
 
+    /**
+     * Allows for adding custom attributes to images like `width` or `height`.
+     *
+     * @param array $Excerpt - The current line's data.
+     * @return array|void
+     */
+    protected function inlineImage($Excerpt){
+        $img = parent::inlineImage($Excerpt);
+
+        $remainder = substr($Excerpt['text'], $img['extent']);
+
+        if (preg_match('/^[ ]*{('.$this->regexAttribute.'+)}/', $remainder, $matches))
+        {
+            $img['element']['attributes'] += $this->parseAttributeData($matches[1]);
+            $img['extent'] += strlen($matches[0]);
+        }
+
+        return $img;
+    }
+
     #
     # ~
     #
@@ -433,7 +453,10 @@ class ParsedownExtra extends Parsedown
     {
         $Data = array();
 
-        $attributes = preg_split('/[ ]+/', $attributeString, - 1, PREG_SPLIT_NO_EMPTY);
+        preg_match_all('/[^\s"]+(?:"[^"]*")?/', $attributeString, $attributes);
+
+        if( count($attributes) ) $attributes = $attributes[0];
+        else return $Data;
 
         foreach ($attributes as $attribute)
         {
@@ -441,9 +464,15 @@ class ParsedownExtra extends Parsedown
             {
                 $Data['id'] = substr($attribute, 1);
             }
-            else # "."
+            elseif ( $attribute[0] === '.' )
             {
                 $classes []= substr($attribute, 1);
+            }
+            elseif ( strpos($attribute, '=') )
+            {
+                preg_match('#([\w-]+)="?([\D\w-]+)"?#', $attribute, $match);
+
+                if( !empty($match) ) $Data[$match[1]] = $match[2];
             }
         }
 
@@ -522,5 +551,5 @@ class ParsedownExtra extends Parsedown
     # Fields
     #
 
-    protected $regexAttribute = '(?:[#.][-\w]+[ ]*)';
+    protected $regexAttribute = '((?:[.#:;=\-"\'\s\w]+))[^}]?';
 }


### PR DESCRIPTION
- I wanted the ability to be able to add `width` & `height` attributes to images but wasn't able to in the current state so I updated the RegEx rules and the `parseAttributeData` method. Now a user can add something like `{.test .fu #bar style="color:red; font-style:italic" data-is-cool="'tis true" lang=en_us}` and it'll render out these attributes `class="test fu" id="bar" style="color:red; font-style:italic" data-is-cool="'tis true" lang="en_us"`.
- I also added the `inlineImage` method so attributes like `width` & `height` can be added.
