### PR TITLE
Refactor PHPUnit bootstrap

### DIFF
--- a/test/ParsedownExtraTest.php
+++ b/test/ParsedownExtraTest.php
@@ -5,16 +5,7 @@ class ParsedownExtraTest extends ParsedownTest
     protected function initDirs()
     {
         $dirs = parent::initDirs();
-
-        $dirs []= dirname(__FILE__).'/data/';
-
+        $dirs[] = __DIR__ . '/data/';
         return $dirs;
-    }
-
-    protected function initParsedown()
-    {
-        $Parsedown = new ParsedownExtra();
-
-        return $Parsedown;
     }
 }

--- a/test/TestParsedown.php
+++ b/test/TestParsedown.php
@@ -1,0 +1,9 @@
+<?php
+
+class TestParsedown extends ParsedownExtra
+{
+    public function getTextLevelElements()
+    {
+        return $this->textLevelElements;
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,10 +1,31 @@
 <?php
 
-$dir = file_exists('../parsedown/')
-    ? '../parsedown/' # child
-    : 'vendor/erusev/parsedown/'; # parent
+// prepare composer autoloader
+$parsedownDir = null;
+if (is_file(__DIR__ . '/../vendor/autoload.php')) {
+    // composer root package
+    require_once(__DIR__ . '/../vendor/autoload.php');
+    $parsedownDir = __DIR__ . '/../vendor/erusev/parsedown';
+} elseif (is_file(__DIR__ . '/../../../../vendor/autoload.php')) {
+    // composer dependency package
+    require_once(__DIR__ . '/../../../../vendor/autoload.php');
+    $parsedownDir = __DIR__ . '/../../../../vendor/erusev/parsedown';
+} else {
+    die("Cannot find 'vendor/autoload.php'. Run \`composer install\`.");
+}
 
-include $dir . 'Parsedown.php';
-include $dir . 'test/ParsedownTest.php';
+// load TestParsedown class
+if (!class_exists('TestParsedown', false)) {
+    if (is_file('test/TestParsedown.php')) {
+        require_once('test/TestParsedown.php');
+    } else {
+        require($parsedownDir . '/test/TestParsedown.php');
+    }
+}
 
-include 'ParsedownExtra.php';
+// load ParsedownTest (ParsedownExtraTest extends ParsedownTest)
+if (is_file($parsedownDir . '/test/ParsedownTest.php')) {
+    require($parsedownDir . '/test/ParsedownTest.php');
+} else {
+    die("Cannot find 'vendor/erusev/parsedown/test/ParsedownTest.php'. Run \`composer install --dev --prefer-source\`.");
+}


### PR DESCRIPTION
This can be used as a template for Parsedown extensions (like Parsedown Extra) to reuse Parsedown's original tests. You can either extend tests (e.g. `ParsedownExtraTest` extends `ParsedownTest`) or reuse them unchanged (e.g. `CommonMarkTest`). Parsedown extensions simply have to implement their own `TestParsedown` class (file `test/TestParsedown.php`) and all original tests will run with a instance of this class, rather than a instance of the original `Parsedown` class.

This PR is a follow-up to erusev/parsedown#423, i.e. you must merge erusev/parsedown#423 first, otherwise this doesn't work.

---

Here are the `phpunit` runs of `CommonMarkTest` and `CommonMarkTestWeak`:

`$ phpunit -c phpunit.xml.dist vendor/erusev/parsedown/test/CommonMarkTest.php`
Output: http://pastebin.com/ZVBjdmvK
```
FFF.FFFFF........FF.....F.F..F...F....FF....FF..F....FFF.F..FFF  63 / 616 ( 10%)
....FFFF....F..FFF.FFFFFFFFFFF.FFF.FFFFFFFFFFFFFF.FFFFFFFFFFF.. 126 / 616 ( 20%)
FFFFFFF...FFFF.FFFFFFFF.F.F.FF.FFFF.F.F.F.FF..FFF.FF......FF... 189 / 616 ( 30%)
.F..FFFFF...F...F..F..FFFF.F.....FFFFFF.FFFFF.F.FFFFFFF.FFFFF.. 252 / 616 ( 40%)
.FFFF.FFFF.F.FF.FFFFFFFFFFF.FF.F.FFF.F.FFFFFFFFFFF.FFFFF.F...FF 315 / 616 ( 51%)
..FFF..FF..FFF...FFF.F...FFFF.F.F..F..FF..FFFFFFF.FF....FF.FFF. 378 / 616 ( 61%)
...FFF.....FF.....FFF...............F..FF.......F..FF......F... 441 / 616 ( 71%)
FFFFFFFFFFFF..FF..FFF.FFFF.FFFFF.FF....F..FFFF..FFF..F..FFF.FFF 504 / 616 ( 81%)
.FFFFF.FFF.......F...F...F.....FFFFF.FF....F.F.FF.......FF.F.F. 567 / 616 ( 92%)
.FE.FF....FF.F..FF.....FFF..F.F..F.F.....F.......

FAILURES!
Tests: 616, Assertions: 615, Failures: 333, Errors: 1.
```

---

`$ phpunit -c phpunit.xml.dist vendor/erusev/parsedown/test/CommonMarkTestWeak.php`
Output: http://pastebin.com/G4cBLfCT
```
FFF.F.F...........F.....F.F..F...F.....F....FF..F.....FF....FFF  63 / 616 ( 10%)
....F.FF........FF..........FF.FF..FFF...F.F...FF...FFFFFFFFF.. 126 / 616 ( 20%)
FFFFFFF...FFFF.FFFFFF.F.F.F..F.FFFF.F.F.F.FF..F.F.FF........... 189 / 616 ( 30%)
....FFFFF...F...F..F..F..F.F......FFFFF.FF.FF.F.FFF...F.FFF.F.. 252 / 616 ( 40%)
.FFFF.FFFF.F.FF.FFFFFFF.F.F....F.FFF.F...FFFFFFFFF.FFFFF......F 315 / 616 ( 51%)
..FFF..FF..FFF...FFF.F...FFFF.F.F..F..FF..FFFFFFF.FF....FF.FFF. 378 / 616 ( 61%)
...FFF.....FF.....FFF...............F..FF.......F..FF......F... 441 / 616 ( 71%)
FFFFFFFFFFFF..FF..FFF.FFFF.FFFFF.FF....F..FFFF..FFF..F..FFF.FFF 504 / 616 ( 81%)
.FFFFF.FFF.......F...F...F.....FFFFF.FF....F.F.FF.......FF.F.F. 567 / 616 ( 92%)
.FE.FF....FF.F..FF.....FFF..F.F..F.F.............

FAILURES!
Tests: 616, Assertions: 615, Failures: 281, Errors: 1.
```