### PR TITLE
Bugfix: reset footnote count after each «text» call

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -43,6 +43,7 @@ class ParsedownExtra extends Parsedown
 
     function text($text)
     {
+        $this->footnoteCount = 0;
         $markup = parent::text($text);
 
         # merge consecutive dl elements

--- a/test/ParsedownExtraTest.php
+++ b/test/ParsedownExtraTest.php
@@ -17,4 +17,22 @@ class ParsedownExtraTest extends ParsedownTest
 
         return $Parsedown;
     }
+
+    public function testMultipleFootnoteCalls()
+    {
+        $parsedown = $this->initParsedown();
+
+        $markdown = file_get_contents(__DIR__.'/data/footnote.md');
+
+        $expectedMarkup = file_get_contents(__DIR__.'/data/footnote.html');
+
+        $expectedMarkup = str_replace("\r\n", "\n", $expectedMarkup);
+        $expectedMarkup = str_replace("\r", "\n", $expectedMarkup);
+
+        $actualMarkup = $parsedown->text($markdown);
+        $this->assertEquals($expectedMarkup, $actualMarkup);
+
+        $actualMarkup = $parsedown->text($markdown);
+        $this->assertEquals($expectedMarkup, $actualMarkup);
+    }
 }


### PR DESCRIPTION
This addresses https://github.com/erusev/parsedown-extra/issues/97 : if you are parsing multiple text within a loop, the footnote count is never reset, so it keeps adding values.

For the tests, I added a new method for testing two calls to the sample text containing the footnotes and checking that after both calls the content is the same. I do not like it that much, because it leaves the code for the test a little bit dirty, as it uses the `ParsedownTest` tests. Another solution would be to create a new test file or, even cleaner, to perform two calls in `ParsedownTest`. I would change them if it is necessary.