### PR TITLE
correctly version compare

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -23,7 +23,7 @@ class ParsedownExtra extends Parsedown
 
     function __construct()
     {
-        if (parent::version < '1.5.0')
+        if (version_compare(parent::version, '1.5.0') < 0)
         {
             throw new Exception('ParsedownExtra requires a later version of Parsedown');
         }


### PR DESCRIPTION
`1.5.0` is not a decimal, meaning that the last `.0` is ignored. That doesn't matter so much though.

What does have an impact is the minor version number. In (casted to float) decimal, `1.15.0` is less than `1.5.0` but as a version number `1.15.0` is greater than `1.5.0`.

Patch fixes this comparison using standard library PHP function.