### PR TITLE
[0.8.1][0.8.x] Add .gitignore + .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Ignore all tests for archive
+/test               export-ignore
+/.gitattributes     export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml.dist   export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock


### PR DESCRIPTION
This PR is cherry-pick of #119 . It fixes #150 

Now, `composer require erusev/parsedown-extra` imports all files of this repo including *test/* directory, and import `autoload` setting but not `autoload-dev` setting.

If `autoload-dev` is not set, *test/* directory will be set sub-namespace of `autoload` because it is sub-directory of the directory used by `autoload` setting. So the class name should be *ParsedownExtra\test\ParsedownExtraTest* but it is named *ParsedownExtraTest*.

The test doesn't need to be imported, so cherry-picking #119 with that setting should solve this problem.