### PR TITLE
Prevent trimming of new line characters in DOMDocument

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -626,6 +626,9 @@ class ParsedownExtra extends Parsedown
 
         # http://stackoverflow.com/q/11309194/200145
         $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        
+        # Ensure that saveHTML() is not remove new line characters. New lines will be split by this character.
+        $DOMDocument->formatOutput = true;
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);


### PR DESCRIPTION
Some PHP environments trims the new line characters of the loaded HTML in a DOMDocument. But the new line characters are needed to split the lines.

Fix #153 

PHP-Version: 7.4.9
Parsedown: 1.8.0-beta-7
ParsedownExtra: 0.8.0

## Input

```html
<div markdown="1">
## Headline
<ul>
<li>Foo</li>
<li>Bar</li>
</ul>

<ul>
<li>Second Foo</li>
<li>Second Bar</li>
</ul>
</div>
```

## Local machine output
```html
<div>
<h2>Headline</h2>
<ul>
<li>Foo</li>
<li>Bar</li>
</ul>
<ul>
<li>Second Foo</li>
<li>Second Bar</li>
</ul>
</div>
```

## Production server output
```html
<div>
<h2>Headline</h2>
<ul><li>Foo</li>
<li>Bar</li>
</ul>
</div>
```

The second list is missing on the production server. The cause is DOMDocument trims the new line characters in some PHP environments.

This PR adds the `formatOutput` property to the DOMDocument Object to solve the issue.