### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
-        "psr-0": {"ParsedownExtra": ""}
+        "classmap": [
+            "ParsedownExtra.php"
+        ]
     },
     "autoload-dev": {
         "psr-0": {


### PR DESCRIPTION
fix composer with warning:


Class ParsedownExtraTest located in ./vendor/erusev/parsedown-extra/test/ParsedownExtraTest.php does not comply with psr-0 autoloading standard. Skipping.