### PR TITLE
Fix PHP 8.2 Deprecation Warning

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], __CLASS__ . '::sortFootnotes');
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {

--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], static::class . '::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], [$this, 'sortFootnotes']);
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {

--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -17,7 +17,7 @@ class ParsedownExtra extends Parsedown
 {
     # ~
 
-    const version = '0.8.0';
+    const version = '0.8.2';
 
     # ~
 
@@ -624,12 +624,15 @@ class ParsedownExtra extends Parsedown
 
         $DOMDocument = new DOMDocument;
 
-        # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
-
-        # http://stackoverflow.com/q/4879946/200145
-        $DOMDocument->loadHTML($elementMarkup);
+        # https://www.php.net/manual/en/domdocument.loadhtml.php#95251
+        $DOMDocument->loadHTML('<?xml encoding="UTF-8"?>' . $elementMarkup);
         $DOMDocument->removeChild($DOMDocument->doctype);
+        foreach ($DOMDocument->childNodes as $Node) {
+            if ($Node->nodeType === XML_PI_NODE) {
+                $DOMDocument->removeChild($Node);
+            }
+        }
+        $DOMDocument->encoding = 'UTF-8';
         $DOMDocument->replaceChild($DOMDocument->firstChild->firstChild->firstChild, $DOMDocument->firstChild);
 
         $elementText = '';

--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], __CLASS__ . '::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], static::class . '::sortFootnotes');
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {


### PR DESCRIPTION
**Source:** https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html

**Note:** Could not use `htmlentities()` here because it will encode the HTML markup which we don&rsquo;t want. The solution comes from a comment in the official PHP website.