### PR TITLE
Fix `Deprecated: Use of "self" in callables is deprecated`

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], self::class . '::sortFootnotes');
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {


### PR DESCRIPTION
Thank you for releasing Parsedown Extra! This fixes an issue for PHP 8.2.

(NOTE: If you merge this PR, please also re-release on Composer. Thanks!)