### PR TITLE
Enhance regex to allow : in class names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.idea/

--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -682,5 +682,5 @@ class ParsedownExtra extends Parsedown
     # Fields
     #
 
-    protected $regexAttribute = '(?:[#.][-\w]+[ ]*)';
+    protected $regexAttribute = '(?:[#.][-\w:]+[ ]*)';
 }


### PR DESCRIPTION
The attributes in the markdown string `## Here's the problem… {#id .text-xl .lg:text-3xl}` are not parsed due to the given regex failing (see [L685](https://github.com/erusev/parsedown-extra/blob/fd33d68349630d18d56367712a64445a6e0bc83e/ParsedownExtra.php#L685)). 

To also allow colons in class names – which is common in [tailwindcss](https://tailwindcss.com/) – this PR changes the regex to `(?:[#.][-\w:]+[ ]*)`, hence allowing also `:` in class names.

Happy coding!
