### PR TITLE
mb_convert_encoding()  deprecated in PHP 8.2+  

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -625,8 +625,9 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
-
+        #$elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8'); mb_convert_encoding deperecated in php 8.2+
+        $elementMarkup = htmlentities($elementMarkup, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);
         $DOMDocument->removeChild($DOMDocument->doctype);


### PR DESCRIPTION
mb_convert_encoding() now deprecated in php 8.2+ replacing with htmlentities()