### PR TITLE
Update ParsedownExtra.php

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -625,7 +625,13 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        # $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        # mb_convert_encoding with 'HTML-ENTITIES' is deprecated since php 8.2
+        $elementMarkup = mb_encode_numericentity(
+            $elementMarkup,
+            [0x80, 0x10FFFF, 0, 0xFFFFFF],
+            'UTF-8'
+        );
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);


### PR DESCRIPTION
mb_convert_encoding with 'HTML-ENTITIES' is deprecated since php 8.2  
use mb_encode_numericentity instead of mb_convert_encoding