### PR TITLE
PHP 8.4 compatibility fixes

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -508,7 +508,7 @@ class ParsedownExtra extends Parsedown
             ),
         );
 
-        uasort($this->DefinitionData['Footnote'], 'self::sortFootnotes');
+        uasort($this->DefinitionData['Footnote'], [$this, 'sortFootnotes']);
 
         foreach ($this->DefinitionData['Footnote'] as $definitionId => $DefinitionData)
         {
@@ -625,7 +625,12 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        # PHP 8.2+ fix: mb_convert_encoding with HTML-ENTITIES is deprecated
+        $elementMarkup = mb_encode_numericentity(
+            $elementMarkup,
+            [0x80, 0x10FFFF, 0, ~0],
+            'UTF-8'
+        );
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "erusev/parsedown-extra",
+    "version": "1.8.0",
     "description": "An extension of Parsedown that adds support for Markdown Extra.",
     "keywords": ["markdown", "markdown extra", "parser", "parsedown"],
     "homepage": "https://github.com/erusev/parsedown-extra",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "erusev/parsedown": "^1.7.4",
+        "erusev/parsedown": "^1.7.4 || ^1.8.0",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "erusev/parsedown": "dev-master",
+        "erusev/parsedown": "^1.7.4",
         "ext-dom": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
* Replace deprecated callable string 'self::sortFootnotes' with array syntax
* Replace deprecated mb_convert_encoding() with HTML-ENTITIES with mb_encode_numericentity()