### PR TITLE
Fixed issue with Deprecation warning

### DIFF
--- a/ParsedownExtra.php
+++ b/ParsedownExtra.php
@@ -625,7 +625,10 @@ class ParsedownExtra extends Parsedown
         $DOMDocument = new DOMDocument;
 
         # http://stackoverflow.com/q/11309194/200145
-        $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        # $elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
+        # The above is throwing Deprecation warnings in PHP 8.5 (probably others)
+        # Found this fix https://www.php.net/manual/en/function.mb-convert-encoding.php#127529
+        $elementMarkup = mb_encode_numericentity( htmlentities( $elementMarkup, ENT_QUOTES, 'UTF-8' ), [0x80, 0x10FFFF, 0, ~0], 'UTF-8' );
 
         # http://stackoverflow.com/q/4879946/200145
         $DOMDocument->loadHTML($elementMarkup);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 ## Parsedown Extra
+### Maintenance fork by DigitalSorceress
+
+**PLEASE NOTE**
+I am not the original creator, but I ran into a deprecation for php 8.5.2 that I needed to fix. I made this branch so I could do a pull request back to the original site
+
+~DigitalSorceress
+
+
+## Original Readme (intact)
 
 An extension of [Parsedown](http://parsedown.org) that adds support for [Markdown Extra](https://michelf.ca/projects/php-markdown/extra/).
 


### PR DESCRIPTION
PHP 8.5.2 (probably others as well) throws Deprecation warning 

> Deprecated: mb_convert_encoding(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in .../ParsedownExtra.php on line 628

I did a bit of digging/ testing and found a fix here:
https://www.php.net/manual/en/function.mb-convert-encoding.php#127529

Replaced the line (628)
```
$elementMarkup = mb_convert_encoding($elementMarkup, 'HTML-ENTITIES', 'UTF-8');
```
With this:
```
$elementMarkup = mb_encode_numericentity( htmlentities( $elementMarkup, ENT_QUOTES, 'UTF-8' ), [0x80, 0x10FFFF, 0, ~0], 'UTF-8' );
```

My testing indicates this fixes the issue. I've not run across any others